### PR TITLE
Added support for querying daily and monthly statistics 

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 const net = require('net');
 const dgram = require('dgram');
+const util = require('util');
 const encryptWithHeader = require('./utils').encryptWithHeader;
 const encrypt = require('./utils').encrypt;
 const decrypt = require('./utils').decrypt;
@@ -20,6 +21,8 @@ var commands = {
   getAwayRules: '{"anti_theft":{"get_rules":{}}}',
   getTimerRules: '{"count_down":{"get_rules":{}}}',
   getConsumption: '{"emeter":{"get_realtime":{}}}',
+  getDailyStatisticsForMonth: '{"emeter":{"get_daystat":{"month":%d,"year":%d}}}',
+  getMonthlyStatisticsForYear: '{"emeter":{"get_monthstat":{"year": %d}}}',
   getTime: '{"time":{"get_time":{}}}',
   getTimeZone: '{"time":{"get_timezone":{}}}',
   getScanInfo: '{"netif":{"get_scaninfo":{"refresh":0,"timeout":17}}}',
@@ -182,6 +185,36 @@ Hs100Api.prototype.setPowerState = function (value) {
 Hs100Api.prototype.getConsumption = function () {
   return this.get(commands.getConsumption).then((data) => {
     return data.emeter;
+  });
+};
+
+/**
+ * Get Daily Statistic for the given month of the given year
+ * @param number [month] the number of month
+ * @param number [year] the full year, e.g. 2016
+ * @returns {Promise.<T>}
+ */
+Hs100Api.prototype.getDailyStatisticsForMonth = function (month, year) {
+  var d = new Date();
+  if (typeof month === 'undefined') month = d.getMonth() + 1;
+  if (typeof year === 'undefined') year = d.getFullYear();
+  return this.get(util.format(commands.getDailyStatisticsForMonth, month, year)).then((data) => {
+        return data.emeter;
+  });
+};
+
+/**
+ * Get Montly Statistic for given Year
+ * @param number [year] the full year, e.g. 2016
+ * @returns {Promise.<T>}
+ */
+Hs100Api.prototype.getMonthlyStatisticsForYear = function (year) {
+  if (typeof year === 'undefined') {
+    var d = new Date();
+    year = d.getFullYear();
+  }
+  return this.get(util.format(commands.getMonthlyStatisticsForYear, year)).then((data) => {
+        return data.emeter;
   });
 };
 


### PR DESCRIPTION
Added support for querying daily and monthly statistics  for TP-Link HS110, i.e.  emeter.get_daystat and emter.get_monthstat. See also https://forum.pimatic.org/topic/2211/new-plugin-for-tp-link-smartplugs-hs100-and-hs110/16 and following.
